### PR TITLE
Update Nethermind executable name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ esac
 JWT=$(cat $JWT_PATH)
 curl -X POST "http://my.dappnode/data-send?key=jwt&data=${JWT}"
 
-exec /nethermind/Nethermind.Runner --config goerli \
+exec /nethermind/nethermind --config goerli \
   --JsonRpc.Enabled=true \
   --JsonRpc.JwtSecretFile=${JWT_PATH} \
   --Init.WebSocketsEnabled true \


### PR DESCRIPTION
We renamed the Nethermind executable from `Nethermind.Runner` to `nethermind`. This PR updates the Docker entry point accordingly.

To be merged once production images are updated with the abovementioned change.